### PR TITLE
Use environment variables

### DIFF
--- a/physics.py
+++ b/physics.py
@@ -4,8 +4,14 @@ import keyboard
 import random
 import win32api, win32con
 import webbrowser
+import os
 
-url = 'https://meet.google.com/cnu-mfbq-wag'
+try:
+    global url
+    url = os.environ['PHYSICS_URL']
+except KeyError:
+    print("Environment variable 'PHYSICS_URL' is not set.")
+    quit()
 
 def click(x,y):
     win32api.SetCursorPos((x,y))


### PR DESCRIPTION
Having the url in plain text is probably not a good idea, so you should instead use environment variables. You can look up how to set these for your respective operating system.